### PR TITLE
c-g: Correct argument parsing

### DIFF
--- a/src/bin/check-graphite/args.rs
+++ b/src/bin/check-graphite/args.rs
@@ -5,6 +5,7 @@ use tabin_plugins::Status;
 
 use assertions::Assertion;
 
+#[derive(Debug, PartialEq)]
 pub(crate) struct Args {
     pub url: String,
     pub path: String,
@@ -15,6 +16,43 @@ pub(crate) struct Args {
     pub graphite_error: Status,
     pub no_data: Status,
     pub print_url: bool,
+}
+
+lazy_static! {
+    // Clap wants its after_help variable to come in as a &str instead of as a
+    // String, so we need to make this static variable to be able to pass it
+    // between functions. Little bit sad.
+    static ref EPILOG: String = format!(
+        "About Assertions:
+
+    Assertions look like 'critical if any point in any series is > 5'.
+
+    They describe what you care about in your graphite data. The structure of
+    an assertion is as follows:
+
+        <errorkind> if <point spec> [in <series spec>] is|are [not] <operator> <threshold>
+
+    Where:
+
+        - `errorkind` is either `critical` or `warning`
+        - `point spec` can be one of:
+            - `any point`
+            - `all points`
+            - `at least <N>% of points`
+            - `most recent point`
+        - `series spec` (optional) can be one of:
+            - `any series`
+            - `all series`
+            - `at least <N>% of series`
+            - `not` is optional, and inverts the following operator
+        - `operator` is one of: `==` `!=` `<` `>` `<=` `>=`
+        - `threshold` is a floating-point value (e.g. 100, 78.0)
+
+    Here are some example assertions:
+
+        - `{}`\n",
+                    ASSERTION_EXAMPLES.join("`\n        - `")
+                );
 }
 
 static ASSERTION_EXAMPLES: &'static [&'static str] = &[
@@ -28,10 +66,9 @@ static ASSERTION_EXAMPLES: &'static [&'static str] = &[
     "critical if most recent point in all series are == 0",
 ];
 
-impl Args {
-    pub fn parse() -> Args {
-        let allowed_no_data = Status::str_values(); // block-local var for borrowck
-        let args = clap::App::new("check-graphite (part of tabin-plugins)")
+fn build_parser() -> clap::App<'static, 'static> {
+    let allowed_no_data = Status::str_values(); // block-local var for borrowck
+    clap::App::new("check-graphite (part of tabin-plugins)")
             .version(env!("CARGO_PKG_VERSION"))
             .author("Brandon W Maister <quodlibetor@gmail.com>")
             .setting(clap::AppSettings::ColoredHelp)
@@ -68,41 +105,21 @@ impl Args {
                     .takes_value(true)
                     .possible_values(&allowed_no_data),
             )
-            .after_help(
-                format!(
-                    "About Assertions:
+            .after_help(&**EPILOG)
+}
 
-    Assertions look like 'critical if any point in any series is > 5'.
+impl Args {
+    /// Parse all arguments provided at the command line
+    pub fn parse() -> Args {
+        Args::from_args(build_parser().get_matches())
+    }
 
-    They describe what you care about in your graphite data. The structure of
-    an assertion is as follows:
+    #[cfg(test)]
+    fn parse_from(args: &[&str]) -> Args {
+        Args::from_args(build_parser().get_matches_from(args))
+    }
 
-        <errorkind> if <point spec> [in <series spec>] is|are [not] <operator> <threshold>
-
-    Where:
-
-        - `errorkind` is either `critical` or `warning`
-        - `point spec` can be one of:
-            - `any point`
-            - `all points`
-            - `at least <N>% of points`
-            - `most recent point`
-        - `series spec` (optional) can be one of:
-            - `any series`
-            - `all series`
-            - `at least <N>% of series`
-            - `not` is optional, and inverts the following operator
-        - `operator` is one of: `==` `!=` `<` `>` `<=` `>=`
-        - `threshold` is a floating-point value (e.g. 100, 78.0)
-
-    Here are some example assertions:
-
-        - `{}`\n",
-                    ASSERTION_EXAMPLES.join("`\n        - `")
-                ).as_ref(),
-            )
-            .get_matches();
-
+    fn from_args(args: clap::ArgMatches) -> Args {
         let assertions = args.values_of("ASSERTION")
             .unwrap()
             .map(|assertion_str| match Assertion::from_str(assertion_str) {
@@ -118,15 +135,15 @@ impl Args {
             Status::Ok.exit();
         }
 
-        let start_offset = value_t!(args.value_of("MINUTES_IN_PAST"), i64).unwrap_or(0);
-        let window = value_t!(args.value_of("MINUTES"), i64).unwrap_or(10);
+        let start_offset = value_t!(args.value_of("window-start"), i64).unwrap_or(0);
+        let window = value_t!(args.value_of("window"), i64).unwrap_or(10);
         Args {
             url: args.value_of("URL").unwrap().to_owned(),
             path: args.value_of("PATH").unwrap().to_owned(),
             assertions: assertions,
             window: start_offset + window,
             start_at: start_offset,
-            retries: value_t!(args.value_of("COUNT"), u8).unwrap_or(4),
+            retries: value_t!(args.value_of("retries"), u8).unwrap_or(4),
             graphite_error: Status::from_str(
                 args.value_of("GRAPHITE_ERROR_STATUS").unwrap_or("unknown"),
             ).unwrap(),
@@ -140,6 +157,7 @@ impl Args {
 #[cfg(test)]
 mod test {
     use super::*;
+    use assertions::*;
 
     #[test]
     fn all_examples_are_accurate() {
@@ -147,5 +165,77 @@ mod test {
             println!("testing `{}`", assertion);
             Assertion::from_str(assertion).unwrap();
         }
+    }
+
+    #[test]
+    fn args_parse_defaults() {
+        let args = Args::parse_from(&[
+            "check-graphite-test",
+            "https://graphite.example.com",
+            "*",
+            "critical if any point is > 0",
+        ]);
+        assert_eq!(
+            args,
+            Args {
+                url: "https://graphite.example.com".into(),
+                path: "*".into(),
+                assertions: vec![
+                    Assertion {
+                        operator: ">".into(),
+                        op_is_negated: NegOp::No,
+                        threshold: 0.0,
+                        point_assertion: PointAssertion::Ratio(0.0),
+                        series_ratio: 0.0,
+                        failure_status: Status::Critical,
+                    },
+                ],
+                window: 10,
+                start_at: 0,
+                retries: 4,
+                graphite_error: Status::Unknown,
+                no_data: Status::Warning,
+                print_url: false,
+            }
+        )
+    }
+
+        #[test]
+    fn args_parse_all_values() {
+        let args = Args::parse_from(&[
+            "check-graphite-test",
+            "--window=5",
+            "--window-start=20",
+            "--retries=7",
+            "--graphite-error=ok",
+            "--no-data=critical",
+            "--print-url",
+            "https://graphite.example.com",
+            "*",
+            "critical if any point is > 0",
+        ]);
+        assert_eq!(
+            args,
+            Args {
+                url: "https://graphite.example.com".into(),
+                path: "*".into(),
+                assertions: vec![
+                    Assertion {
+                        operator: ">".into(),
+                        op_is_negated: NegOp::No,
+                        threshold: 0.0,
+                        point_assertion: PointAssertion::Ratio(0.0),
+                        series_ratio: 0.0,
+                        failure_status: Status::Critical,
+                    },
+                ],
+                window: 25,
+                start_at: 20,
+                retries: 7,
+                graphite_error: Status::Ok,
+                no_data: Status::Critical,
+                print_url: true,
+            }
+        )
     }
 }

--- a/src/bin/check-graphite/main.rs
+++ b/src/bin/check-graphite/main.rs
@@ -2,14 +2,15 @@ extern crate chrono;
 #[macro_use]
 extern crate clap;
 extern crate itertools;
+#[macro_use]
+extern crate lazy_static;
 extern crate reqwest;
-extern crate url;
-
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 extern crate tabin_plugins;
+extern crate url;
 
 mod args;
 mod assertions;

--- a/src/bin/check-procs.rs
+++ b/src/bin/check-procs.rs
@@ -238,16 +238,17 @@ mod unit {
         assert_eq!(args.states, [State::Zombie, State::Sleeping]);
     }
 
-
     #[test]
     fn filter_procs_handles_patterns() {
         let mut procs = vec![Process::default(); 5];
-        procs[2].cmdline.raw.append(&mut vec!["hello".into(), "jar".into()]);
+        procs[2]
+            .cmdline
+            .raw
+            .append(&mut vec!["hello".into(), "jar".into()]);
         let proc_map = vec_to_procmap(procs);
         let filtered = filter_procs(regex("llo.*ar"), &[], &proc_map);
         assert_eq!(filtered.len(), 1);
     }
-
 
     #[test]
     fn filter_procs_handles_single_state() {


### PR DESCRIPTION
Clap changed its argument mapping logic to use the long option name instead of
the metavariable name.

Updated to use the correct names, and added a test that we are always getting
the values that we expect.